### PR TITLE
use enum literal for package name, up to version 0.2.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
-    .name = "sdl2-prebuilt-x86_64-linux-gnu",
-    .version = "0.1.0",
+    .name = .sdl2_prebuilt_x86_64_linux_gnu,
+    .version = "0.2.0",
     .paths = .{
         "build.zig.zon",
         "lib",


### PR DESCRIPTION
- Change package name to enum literal
- Replace '-' with '_' in name as they are not allowed
- Up package version to '0.2.0' from '0.1.0'